### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "bugs": {
     "url": "https://github.com/jack-blackson/ioBroker.meteoalarm/issues"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^2.6.8",
     "@iobroker/testing": "^4.0.0",


### PR DESCRIPTION
As your adapter no longer is tested agaoints node 16 it should require node 18 starting with the next regular (minor or major) version update.

Please review PR an merge.